### PR TITLE
feat(ui): implement mobile menu and hero section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -351,6 +351,122 @@ header {
     background-color: var(--yellow);
 }
 
+/* Mobile Menu */
+.mobile-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--primary-gradient);
+    padding: 1rem;
+    z-index: 999;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    border-radius: 0 0 20px 20px;
+    animation: slideDown 0.3s ease-out;
+}
+
+.mobile-menu.active {
+    display: block;
+}
+
+.mobile-menu a {
+    display: block;
+    color: white;
+    text-decoration: none;
+    padding: 1rem;
+    border-radius: 10px;
+    margin-bottom: 0.5rem;
+    transition: var(--transition);
+    font-weight: 500;
+}
+
+.mobile-menu a:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateX(5px);
+}
+
+/* Hero Section */
+.hero {
+    background: linear-gradient(135deg, var(--secondary-color) 0%, var(--primary-color) 100%);
+    color: white;
+    padding: 2rem 1rem;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    animation: fadeIn 1s ease-out;
+}
+
+.hero::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(circle, rgba(255,255,255,0.1) 0%, transparent 70%);
+    transform: rotate(30deg);
+    animation: rotate 20s linear infinite;
+}
+
+@keyframes rotate {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.hero-content {
+    position: relative;
+    z-index: 2;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.hero h1 {
+    font-size: 2rem;
+    margin-bottom: 0.75rem;
+    text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    animation: slideUp 0.8s ease-out;
+}
+
+.hero p {
+    font-size: 1.1rem;
+    margin-bottom: 1.5rem;
+    opacity: 0.9;
+    animation: slideUp 1s ease-out;
+}
+
+.hero-stats {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
+}
+
+.stat-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.75rem 1.25rem;
+    border-radius: 12px;
+    backdrop-filter: blur(10px);
+    transition: var(--transition);
+    animation: fadeIn 1.2s ease-out;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.stat-item:hover {
+    transform: translateY(-5px);
+    background: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
+}
+
+.stat-item i {
+    font-size: 1.5rem;
+}
+
 /* Mobile Quick Actions */
 .mobile-quick-actions {
     display: none;
@@ -1348,17 +1464,17 @@ footer p {
         grid-template-columns: 1fr;
     }
     
-    /* Batch Selection */
+    /* Batch Selection - Left to Right */
     .batch-selector {
-        flex-direction: column;
-        align-items: center;
+        flex-direction: row;
+        justify-content: center;
         gap: 0.75rem;
     }
     
     .batch-select-btn {
-        width: 90%;
         padding: 0.75rem 1rem;
-        font-size: 0.9rem;
+        font-size: 0.85rem;
+        min-width: 70px;
     }
     
     /* Footer - Left to Right Layout */
@@ -1479,7 +1595,8 @@ footer p {
     
     .batch-select-btn {
         padding: 0.6rem 0.8rem;
-        font-size: 0.85rem;
+        font-size: 0.8rem;
+        min-width: 65px;
     }
     
     .stat-item {
@@ -1514,5 +1631,18 @@ footer p {
     /* Hide desktop quick actions on mobile */
     .quick-actions {
         display: none;
+    }
+    
+    /* Batch Selection - Stack on very small screens */
+    @media (max-width: 360px) {
+        .batch-selector {
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        
+        .batch-select-btn {
+            width: 90%;
+        }
     }
 }

--- a/index.html
+++ b/index.html
@@ -21,12 +21,13 @@
             <span class="batch-indicator" id="currentBatch">Batch 1</span>
         </div>
         
-        <nav class="nav-links" id="mobile-nav">
+        <!-- Mobile Menu -->
+        <div class="mobile-menu" id="mobileMenu">
             <a href="#all-semesters"><i class="fas fa-graduation-cap"></i> Semesters</a>
             <a href="https://drive.google.com/drive/folders/1rtMMO0iTKQCMBesbmRIVS3COeyEbfsPv?usp=sharing" target="_blank"><i class="fas fa-folder-open"></i> Resources</a>
             <a href="https://bup.edu.bd/department_home/8" target="_blank"><i class="fas fa-building"></i> Department</a>
             <a href="https://bupbloodbank.xyz/" target="_blank"><i class="fas fa-tint"></i> Blood Bank</a>
-        </nav>
+        </div>
         
         <!-- Mobile Nav Links in Navbar -->
         <div class="mobile-nav-links">
@@ -53,7 +54,7 @@
             <button id="darkModeToggle" class="dark-mode-toggle-navbar">
                 <i class="fas fa-sun"></i>
             </button>
-            <div class="hamburger" onclick="toggleMenu()">
+            <div class="hamburger" id="hamburger" onclick="toggleMenu()">
                 <div></div>
                 <div></div>
                 <div></div>
@@ -245,14 +246,6 @@
                 });
             });
         }
-        
-        // Add mobile bookmarks button functionality
-        document.addEventListener('DOMContentLoaded', function() {
-            const mobileBookmarksBtn = document.getElementById('showBookmarksMobile');
-            if (mobileBookmarksBtn) {
-                mobileBookmarksBtn.addEventListener('click', showBookmarks);
-            }
-        });
     </script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -26,6 +26,8 @@ const closeBookmarksModalBtn = document.getElementById('closeBookmarksModal');
 const bookmarksList = document.getElementById('bookmarksList');
 
 const darkModeToggle = document.getElementById('darkModeToggle');
+const hamburger = document.getElementById('hamburger');
+const mobileMenu = document.getElementById('mobileMenu');
 
 // Initialize the application
 document.addEventListener('DOMContentLoaded', async () => {
@@ -106,6 +108,12 @@ function setupEventListeners() {
     // Bookmarks modal
     if (showBookmarksBtn) {
         showBookmarksBtn.addEventListener('click', showBookmarks);
+    }
+
+    // Mobile bookmarks button
+    const mobileBookmarksBtn = document.getElementById('showBookmarksMobile');
+    if (mobileBookmarksBtn) {
+        mobileBookmarksBtn.addEventListener('click', showBookmarks);
     }
 
     if (closeBookmarksModalBtn) {
@@ -327,9 +335,7 @@ function initDarkMode() {
     document.documentElement.setAttribute('data-theme', 'dark');
     if (darkModeToggle) {
         darkModeToggle.innerHTML = '<i class="fas fa-sun"></i>';
-    }
-
-    if (darkModeToggle) {
+        
         darkModeToggle.addEventListener('click', () => {
             const currentTheme = document.documentElement.getAttribute('data-theme');
             const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
@@ -578,11 +584,8 @@ async function loadExternalSubjectData() {
 
 // Improved mobile menu toggle
 function toggleMenu() {
-    const nav = document.getElementById('mobile-nav');
-    const hamburger = document.querySelector('.hamburger');
-    
-    if (nav && hamburger) {
-        nav.classList.toggle('active');
+    if (mobileMenu && hamburger) {
+        mobileMenu.classList.toggle('active');
         hamburger.classList.toggle('active');
     }
 }
@@ -626,13 +629,10 @@ function toggleFAQ(element) {
 
 // Close mobile menu when clicking outside
 document.addEventListener('click', function(event) {
-    const nav = document.getElementById('mobile-nav');
-    const hamburger = document.querySelector('.hamburger');
-    
-    if (nav && hamburger && nav.classList.contains('active')) {
-        // Check if click is outside nav and hamburger
-        if (!nav.contains(event.target) && !hamburger.contains(event.target)) {
-            nav.classList.remove('active');
+    if (mobileMenu && hamburger && mobileMenu.classList.contains('active')) {
+        // Check if click is outside menu and hamburger
+        if (!mobileMenu.contains(event.target) && !hamburger.contains(event.target)) {
+            mobileMenu.classList.remove('active');
             hamburger.classList.remove('active');
         }
     }


### PR DESCRIPTION
Adds a mobile menu for better navigation on smaller screens and implements a hero section with dynamic stats and animations. The mobile menu is hidden by default and toggled by a hamburger icon. The hero section provides a visually appealing introduction with key statistics.

The batch selection buttons are now left to right on larger screens and stack on very small screens.